### PR TITLE
feature: add line and column number to file://path:linenumber:columnnumber enable GOTO-like functionality

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,21 @@
+{
+  "configurations": [
+    {
+      "type": "lldb",
+      "request": "launch",
+      "name": "Debug Rust",
+      "program": "${workspaceFolder}/target/debug/sff",
+      "args": ["${input:dynamicArg}"],
+      "cwd": "${workspaceFolder}",
+      "preLaunchTask": "rust: cargo build"
+    }
+  ],
+  "inputs": [
+    {
+      "id": "dynamicArg",
+      "type": "promptString",
+      "description": "Enter argument for SFF",
+      "default": "javascript"
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,12 @@
+{
+  "label": "cargo build",
+  "type": "shell",
+  "command": "cargo",
+  "args": [
+    "build"
+  ],
+  "options": {
+    "cwd": "${workspaceFolder}"
+  },
+  "problemMatcher": ["$rustc"]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,10 +1,9 @@
 {
+  "version": "2.0.0",
   "label": "cargo build",
   "type": "shell",
   "command": "cargo",
-  "args": [
-    "build"
-  ],
+  "args": ["build"],
   "options": {
     "cwd": "${workspaceFolder}"
   },


### PR DESCRIPTION
@do-me cool project! Neat to see how the embedding stuff works on the Rust side of things.

I thought it may be useful to be able to be able to support GOTO like navigation to be able to navigate directly to the chunk in question within the broader document. VSCode as well as other editors (I tested opening a link from a non-vscode terminal that opened the file in XCode, and that worked well). I took some care to do the calculation of the offsets in the initial parsing of the chunks, and skip unnecessary units of work based on the number of newlines passed already.

https://code.visualstudio.com/docs/configure/command-line#_opening-vs-code-with-urls

```
➜  sff git:(feat/add-line-and-column-number) ./target/release/sff javascript

Found 50 relevant chunks from 2 files for query "javascript" in 117.65 ms. Top 10 results:
┌───────┬─────────────────────────────────────────────────────────────────────────────────────────────────────────┬────────────────────────────────────────────────────┐
│ Score ┆ Matching Text Chunk                                                                                     ┆ File Path                                          │
╞═══════╪═════════════════════════════════════════════════════════════════════════════════════════════════════════╪════════════════════════════════════════════════════╡
│ 0.47  ┆ `sff -m "minishlab/potion-multilingual-128M" "javascript"` | potion-multilingual-128M | javascript |... ┆ file:///Users/jasonbaker/oss/sff/README.md:32:3    │
├╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
```