### PR TITLE
feat: add JSON output format and pyproject.toml configuration support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -377,6 +377,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "errno"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -465,6 +471,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "half"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -473,6 +485,12 @@ dependencies = [
  "cfg-if",
  "crunchy",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 
 [[package]]
 name = "heck"
@@ -608,6 +626,16 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2481980430f9f78649238835720ddccc57e52df14ffce1c6f37391d61b563e9"
+dependencies = [
+ "equivalent",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1325,9 +1353,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
 dependencies = [
  "itoa",
  "memchr",
@@ -1336,17 +1364,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "sff"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",
  "comfy-table",
+ "glob",
  "indicatif",
  "model2vec-rs",
  "ndarray",
  "percent-encoding",
  "rayon",
+ "serde",
+ "serde_json",
+ "toml",
  "walkdir",
 ]
 
@@ -1508,6 +1549,47 @@ dependencies = [
  "unicode-segmentation",
  "unicode_categories",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "unicode-ident"
@@ -1884,6 +1966,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,10 @@ ndarray = "0.15.6"
 percent-encoding = "2.3.1"
 rayon = "1.8.1"
 walkdir = "2.4.0"
+serde = { version = "1.0.219", features = ["derive"] }
+serde_json = "1.0.143"
+toml = "0.8"
+glob = "0.3.3"
 
 [profile.release]
 strip = true  # Automatically strip symbols from the binary.

--- a/README.md
+++ b/README.md
@@ -8,13 +8,28 @@
 
 ## Installation & Quick Start
 
+### Install from crates.io
+
 You can install `sff` using Cargo:
 
 ```bash
 cargo install sff
 sff "project ideas for rust"
 ```
-Ensure `~/.cargo/bin` is in your system's `PATH`. Deafult is cwd with `--path .`
+Ensure `~/.cargo/bin` is in your system's `PATH`. Default is cwd with `--path .`
+
+### Build from Source
+
+To build and install from source:
+
+```bash
+git clone https://github.com/do-me/sff.git
+cd sff
+cargo build --release
+cargo install --path .
+```
+
+The binary will be available in `target/release/sff` and installed to `~/.cargo/bin/sff`.
 
 I use this tool myself to scan my personal notes. In the past these were simple .txt files in a folder until I migrated everything to iCloud + Obsidian. Here is some sample output from some random notes:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[tool.sff]
+exclude_dirs = [
+    "target",
+    "**/.git",
+    "**/testdata",
+]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -33,4 +33,8 @@ pub struct Args {
     /// Enable verbose mode to print detailed timings for nerds
     #[arg(short = 'v', long)]
     pub verbose: bool,
+
+    /// Output results in JSON format instead of table
+    #[arg(short = 'j', long)]
+    pub json: bool,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,11 +5,13 @@ use crate::cli::Args;
 use anyhow::{Context, Result};
 use clap::Parser;
 use comfy_table::{presets::UTF8_FULL, Cell, ContentArrangement, Table};
+use glob::Pattern;
 use indicatif::{ProgressBar, ProgressStyle};
 use model2vec_rs::model::StaticModel; // Using the provided model2vec-rs
 use ndarray::{Array1, ArrayView1};
 use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
 use rayon::prelude::*;
+use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -28,12 +30,46 @@ struct TextChunk {
     offset_in_line: usize,
 }
 
+#[derive(Serialize)]
 struct SearchResult {
     score: f32,
     path: PathBuf,
     chunk: String,
     line_number: usize,
     offset_in_line: usize,
+}
+
+#[derive(Serialize)]
+struct JsonOutput {
+    query: String,
+    total_chunks: usize,
+    total_files: usize,
+    search_time_ms: f64,
+    results: Vec<JsonResult>,
+}
+
+#[derive(Serialize)]
+struct JsonResult {
+    score: f32,
+    file_path: String,
+    chunk: String,
+    line_number: usize,
+    offset_in_line: usize,
+}
+
+#[derive(Deserialize, Debug)]
+struct PyProjectToml {
+    tool: Option<ToolSection>,
+}
+
+#[derive(Deserialize, Debug)]
+struct ToolSection {
+    sff: Option<SffConfig>,
+}
+
+#[derive(Deserialize, Debug)]
+struct SffConfig {
+    exclude_dirs: Option<Vec<String>>,
 }
 
 const PATH_ENCODE_SET: &AsciiSet = &CONTROLS
@@ -73,6 +109,37 @@ where
     }
 }
 
+fn load_exclude_dirs(search_path: &Path) -> Vec<String> {
+    let mut current_dir = search_path.to_path_buf();
+    
+    // Walk up the directory tree looking for pyproject.toml
+    loop {
+        let pyproject_path = current_dir.join("pyproject.toml");
+        
+        if pyproject_path.exists() {
+            if let Ok(contents) = fs::read_to_string(&pyproject_path) {
+                if let Ok(parsed) = toml::from_str::<PyProjectToml>(&contents) {
+                    if let Some(exclude_dirs) = parsed
+                        .tool
+                        .and_then(|t| t.sff)
+                        .and_then(|s| s.exclude_dirs)
+                    {
+                        return exclude_dirs;
+                    }
+                }
+            }
+        }
+        
+        // Move up one directory
+        if !current_dir.pop() {
+            break;
+        }
+    }
+    
+    // No default exclude patterns - let users configure them explicitly
+    vec![]
+}
+
 fn main() -> Result<()> {
     let program_total_start_time = Instant::now();
     let args = Args::parse();
@@ -84,10 +151,36 @@ fn main() -> Result<()> {
         args.verbose,
         false,
         || {
-            let walker =
-                WalkDir::new(&args.path).max_depth(if args.recursive { usize::MAX } else { 1 });
-            let collected_chunks: Vec<TextChunk> = walker
+            // Load exclude patterns from pyproject.toml
+            let exclude_patterns = load_exclude_dirs(&args.path);
+            let exclude_patterns: Vec<Pattern> = exclude_patterns
+                .iter()
+                .filter_map(|p| Pattern::new(p).ok())
+                .collect();
+                
+            let walker = WalkDir::new(&args.path)
+                .max_depth(if args.recursive { usize::MAX } else { 1 })
                 .into_iter()
+                .filter_entry(|entry| {
+                    // Get path relative to search root
+                    let relative_path = entry.path().strip_prefix(&args.path)
+                        .unwrap_or(entry.path())
+                        .to_string_lossy();
+                    
+                    // Check if any exclude pattern matches
+                    let should_exclude = exclude_patterns.iter().any(|pattern| {
+                        pattern.matches(&relative_path) || 
+                        pattern.matches(&entry.path().to_string_lossy())
+                    });
+                    
+                    if should_exclude && args.verbose {
+                        eprintln!("[VERBOSE] Excluding: {}", relative_path);
+                    }
+                    
+                    !should_exclude
+                });
+            
+            let collected_chunks: Vec<TextChunk> = walker
                 .filter_map(Result::ok)
                 .par_bridge()
                 .filter(|e| e.file_type().is_file())
@@ -204,92 +297,132 @@ fn main() -> Result<()> {
     }
     bar_chunk_embedding.set_message("Embedding file chunks...");
 
-    let chunk_embeddings: Vec<Vec<f32>> = timed_block("Chunk Embedding Generation", args.verbose, true, || {
-        chunks
-            .par_chunks(CHUNK_EMBEDDING_BATCH_SIZE)
-            .flat_map(|batch_of_text_chunks| {
-                let texts_for_batch: Vec<String> = batch_of_text_chunks.iter().map(|tc| tc.text.clone()).collect();
-                let embeddings_for_batch = model_arc.encode(&texts_for_batch);
-                bar_chunk_embedding.inc(batch_of_text_chunks.len() as u64);
-                embeddings_for_batch
-            })
-            .collect()
-    });
+    let chunk_embeddings: Vec<Vec<f32>> =
+        timed_block("Chunk Embedding Generation", args.verbose, true, || {
+            chunks
+                .par_chunks(CHUNK_EMBEDDING_BATCH_SIZE)
+                .flat_map(|batch_of_text_chunks| {
+                    let texts_for_batch: Vec<String> = batch_of_text_chunks
+                        .iter()
+                        .map(|tc| tc.text.clone())
+                        .collect();
+                    let embeddings_for_batch = model_arc.encode(&texts_for_batch);
+                    bar_chunk_embedding.inc(batch_of_text_chunks.len() as u64);
+                    embeddings_for_batch
+                })
+                .collect()
+        });
     bar_chunk_embedding.finish_with_message("Done embedding chunks.");
 
     // 5. CALCULATE SIMILARITY AND SORT RESULTS
     let query_vec: Array1<f32> = Array1::from(query_embedding);
 
-    let mut results: Vec<SearchResult> = timed_block("Similarity Calculation & Sorting", args.verbose,true, || {
-        let mut collected_results: Vec<SearchResult> = chunk_embeddings
-            .par_iter()
-            .enumerate()
-            .map(|(i, emb_ref)| {
-                let chunk_vec_view: ArrayView1<f32> = ArrayView1::from(emb_ref);
-                let sim = cosine_similarity(query_vec.view(), chunk_vec_view);
-                SearchResult {
-                    score: sim,
-                    path: chunks[i].path.clone(),
-                    chunk: chunks[i].text.clone(),
-                    line_number: chunks[i].line_number.clone(),
-                    offset_in_line: chunks[i].offset_in_line.clone(),
-                }
-            })
-            .collect();
+    let mut results: Vec<SearchResult> = timed_block(
+        "Similarity Calculation & Sorting",
+        args.verbose,
+        true,
+        || {
+            let mut collected_results: Vec<SearchResult> = chunk_embeddings
+                .par_iter()
+                .enumerate()
+                .map(|(i, emb_ref)| {
+                    let chunk_vec_view: ArrayView1<f32> = ArrayView1::from(emb_ref);
+                    let sim = cosine_similarity(query_vec.view(), chunk_vec_view);
+                    SearchResult {
+                        score: sim,
+                        path: chunks[i].path.clone(),
+                        chunk: chunks[i].text.clone(),
+                        line_number: chunks[i].line_number.clone(),
+                        offset_in_line: chunks[i].offset_in_line.clone(),
+                    }
+                })
+                .collect();
 
-        collected_results.par_sort_unstable_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
-        collected_results
-    });
+            collected_results.par_sort_unstable_by(|a, b| {
+                b.score
+                    .partial_cmp(&a.score)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            });
+            collected_results
+        },
+    );
 
-    // 6. PRETTY-PRINT THE RESULTS
+    // 6. OUTPUT THE RESULTS
     if args.verbose {
         eprintln!("[VERBOSE] Result Printing Start");
     }
 
     let elapsed_time_total = program_total_start_time.elapsed();
-    println!(
-        "\nFound {} relevant chunks from {} files for query \"{}\" in {:.2} ms. Top {} results:",
-        results.len(),
-        file_count,
-        query_string,
-        elapsed_time_total.as_secs_f64() * 1000.0,
-        args.limit.min(results.len())
-    );
 
-    if !results.is_empty() {
-        let mut table = Table::new();
-        table
-            .load_preset(UTF8_FULL)
-            .set_content_arrangement(ContentArrangement::Dynamic)
-            .set_header(vec![
-                Cell::new("Score"),
-                Cell::new("Matching Text Chunk"),
-                Cell::new("File Path"),
-            ]);
+    if args.json {
+        // JSON output
+        let json_results: Vec<JsonResult> = results
+            .iter()
+            .take(args.limit)
+            .map(|result| JsonResult {
+                score: result.score,
+                file_path: result.path.to_string_lossy().to_string(),
+                chunk: result.chunk.clone(),
+                line_number: result.line_number,
+                offset_in_line: result.offset_in_line,
+            })
+            .collect();
 
-        for result in results.iter_mut().take(args.limit) {
-            const MAX_CHUNK_DISPLAY_LEN: usize = 100;
-            if result.chunk.chars().count() > MAX_CHUNK_DISPLAY_LEN {
-                result.chunk = result
-                    .chunk
-                    .chars()
-                    .take(MAX_CHUNK_DISPLAY_LEN)
-                    .collect::<String>()
-                    + "...";
-            }
-            table.add_row(vec![
-                Cell::new(format!("{:.2}", result.score)),
-                Cell::new(&result.chunk),
-                Cell::new(format_path_for_terminal(
-                    &result.path,
-                    &result.line_number,
-                    &result.offset_in_line,
-                )),
-            ]);
-        }
-        println!("{table}");
+        let json_output = JsonOutput {
+            query: query_string,
+            total_chunks: results.len(),
+            total_files: file_count,
+            search_time_ms: elapsed_time_total.as_secs_f64() * 1000.0,
+            results: json_results,
+        };
+
+        println!("{}", serde_json::to_string_pretty(&json_output)?);
     } else {
-        println!("No matches found.");
+        // Table output (existing logic)
+        println!(
+            "\nFound {} relevant chunks from {} files for query \"{}\" in {:.2} ms. Top {} results:",
+            results.len(),
+            file_count,
+            query_string,
+            elapsed_time_total.as_secs_f64() * 1000.0,
+            args.limit.min(results.len())
+        );
+
+        if !results.is_empty() {
+            let mut table = Table::new();
+            table
+                .load_preset(UTF8_FULL)
+                .set_content_arrangement(ContentArrangement::Dynamic)
+                .set_header(vec![
+                    Cell::new("Score"),
+                    Cell::new("Matching Text Chunk"),
+                    Cell::new("File Path"),
+                ]);
+
+            for result in results.iter_mut().take(args.limit) {
+                const MAX_CHUNK_DISPLAY_LEN: usize = 100;
+                if result.chunk.chars().count() > MAX_CHUNK_DISPLAY_LEN {
+                    result.chunk = result
+                        .chunk
+                        .chars()
+                        .take(MAX_CHUNK_DISPLAY_LEN)
+                        .collect::<String>()
+                        + "...";
+                }
+                table.add_row(vec![
+                    Cell::new(format!("{:.2}", result.score)),
+                    Cell::new(&result.chunk),
+                    Cell::new(format_path_for_terminal(
+                        &result.path,
+                        &result.line_number,
+                        &result.offset_in_line,
+                    )),
+                ]);
+            }
+            println!("{table}");
+        } else {
+            println!("No matches found.");
+        }
     }
 
     if args.verbose {


### PR DESCRIPTION
## Summary
- Add `--json`/`-j` flag for JSON output format instead of table display  
- Add support for loading `exclude_dirs` configuration from `pyproject.toml`
- Configuration is loaded by walking up directory tree to find `pyproject.toml`
- Add build from source instructions to README

## Features Added
- **JSON Output**: New `--json` flag outputs structured JSON instead of formatted table
- **Configuration Support**: Load exclude directory patterns from `pyproject.toml` under `[tool.sff]` section
- **Documentation**: Added build from source instructions and fixed typos

## Test Plan
- [x] Verify JSON output format is valid and contains expected fields
- [x] Test pyproject.toml configuration loading with exclude patterns
- [x] Ensure backward compatibility with existing table output format
- [x] Confirm build instructions work correctly